### PR TITLE
Insert proper line returns for multiple keys

### DIFF
--- a/ssh-allow-friend
+++ b/ssh-allow-friend
@@ -160,7 +160,8 @@ setup () {
 
         mkdir -p $HOME/.ssh/
         echo $USERKEY >> $HOME/.ssh/authorized_keys
-        sed -i 's/ ssh/\nssh/g' $HOME/.ssh/authorized_keys
+        sed -i 's/ ssh-/\nssh-/g' $HOME/.ssh/authorized_keys
+        sed -i 's/ ecdsa-/\necdsa-/g' $HOME/.ssh/authorized_keys
     ) 200>/tmp/.ssh-allow-friend.$USER.lock
 }
 

--- a/ssh-allow-friend
+++ b/ssh-allow-friend
@@ -160,6 +160,7 @@ setup () {
 
         mkdir -p $HOME/.ssh/
         echo $USERKEY >> $HOME/.ssh/authorized_keys
+        sed -i 's/ ssh/\nssh/g' $HOME/.ssh/authorized_keys
     ) 200>/tmp/.ssh-allow-friend.$USER.lock
 }
 


### PR DESCRIPTION
Fixed an issue where users with multiple keys in their Github account would have all keys pasted on one line in authorized_keys, separated by a single space.

Adding this line replaces that space with a newline character for each subsequent key. This does not appear to interfere with key removal.